### PR TITLE
Improve modal ux

### DIFF
--- a/app/frontend/src/component/mainpage/MainPage.tsx
+++ b/app/frontend/src/component/mainpage/MainPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Modal } from '../modal/Modal'
+import { ModalController } from '../modal/Modal'
 import NavBar from './navbar/NavBar'
 import '/src/scss/MainPage.scss'
 import EasyFetch from './../../utils/EasyFetch';
@@ -40,9 +40,9 @@ const MainPage = (): JSX.Element => {
       <button id="game" onClick={() => setIsGameOpen(true)}>
         <img src="https://img.icons8.com/ios/50/000000/head-to-head.png"/>
       </button>
-      <Modal content={() => <h1>Record</h1>} display={isRecordOpen} handleClose={() => setIsRecordOpen(false)}/>
-      <Modal content={() => <h1>Chat</h1>} display={isChatOpen} handleClose={() => setIsChatOpen(false)}/>
-      <Modal content={() => <h1>Game</h1>} display={isGameOpen} handleClose={() => setIsGameOpen(false)}/>
+      <ModalController content={() => <h1>Record</h1>} display={isRecordOpen} closer={() => setIsRecordOpen(false)}/>
+      <ModalController content={() => <h1>Chat</h1>} display={isChatOpen} closer={() => setIsChatOpen(false)}/>
+      <ModalController content={() => <h1>Game</h1>} display={isGameOpen} closer={() => setIsGameOpen(false)}/>
     </>
   );
 }

--- a/app/frontend/src/component/mainpage/navbar/NavBar.tsx
+++ b/app/frontend/src/component/mainpage/navbar/NavBar.tsx
@@ -1,5 +1,5 @@
 import { MouseEvent, useEffect, useState } from "react";
-import { Modal, ConfigContent } from "../../modal/Modal";
+import { ModalController, ConfigContent } from "../../modal/Modal";
 import "/src/scss/NavBar.scss";
 
 interface navBarProps {
@@ -101,10 +101,10 @@ const NavBar = (props: navBarProps): JSX.Element => {
           alt="Config"
           onClick={() => setIsConfigOpen(true)}
         />
-        <Modal
+        <ModalController
           content={ConfigContent}
           display={isConfigOpen}
-          handleClose={() => setIsConfigOpen(false)}
+          closer={() => setIsConfigOpen(false)}
         />
       </div>
     </nav>

--- a/app/frontend/src/component/modal/Modal.tsx
+++ b/app/frontend/src/component/modal/Modal.tsx
@@ -3,32 +3,49 @@ import "/src/scss/Modal.scss";
 
 import ConfigContent from './content/ConfigContent'
 
-interface modalProps {
+/*!
+ * @author yochoi
+ * @brief display 에 맞춰 Modal 컴포넌트를 마운트, 언마운트 해주는 FC
+ * @param[in] content: Modal 안에 들어갈 FC
+ * @param[in] display: Modal 의 display 여부
+ * @param[in] closer: Modal 의 상위 컴포넌트에서 display를 제어해줄 함수
+ */
+
+interface modalControllerProps {
   content: FC,
   display: boolean,
-  handleClose: () => void
+  closer: () => void
 };
+
+const ModalController: FC<modalControllerProps> = ({content, display, closer}): JSX.Element => {
+  if (display) {
+    return <Modal content={content} closer={closer}/>;
+  } else {
+    return <></>;
+  }
+}
 
 /*!
  * @author yochoi
- * @brief 함수 컴포넌트를 모달 형태로 띄워주는 컴포넌트
- * @param[in] props.content 모달 안에 들어갈 함수형 컴포넌트
- * @param[in] props.display 모달을 display 할지 여부, 상위 컴포넌트에서 State로 컨트롤 해야함
- * @param[in] props.handleClose 상위 컴포넌트의 modalDisplay State를 컨트롤 해줄 함수
+ * @brief FC를 Modal 형태로 띄워주는 컴포넌트
+ * @param[in] content: Modal 안에 들어갈 함수형 컴포넌트
+ * @param[in] closer: Modal 의 상위 컴포넌트에서 display를 제어해줄 함수
  */
 
-const Modal = (props: modalProps): JSX.Element => {
+interface modalPros {
+  content: FC,
+  closer: () => void
+}
 
-  const display: string = `${props.display ? 'display-block' : 'display-none'}`;
-
+const Modal: FC<modalPros> = ({content, closer}): JSX.Element => {
   return (
-    <div className={"modal " + display}>
-      <div className="modal content">
-        <img src="./public/closeWindow.png" onClick={props.handleClose} alt="close" />
-        {props.content({})}
+    <div id="modal">
+      <div id="content">
+        <img src="./public/closeWindow.png" onClick={closer}alt="close" />
+        {content({})}
       </div>
     </div>
   );
 }
 
-export { Modal, ConfigContent };
+export { ModalController, ConfigContent };

--- a/app/frontend/src/component/modal/Modal.tsx
+++ b/app/frontend/src/component/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import React, { FC } from 'react';
 import "/src/scss/Modal.scss";
 
 import ConfigContent from './content/ConfigContent'
@@ -38,10 +38,18 @@ interface modalPros {
 }
 
 const Modal: FC<modalPros> = ({content, closer}): JSX.Element => {
+
+  const detectOutsideOfModal = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (e.target === e.currentTarget) {
+      closer();
+    }
+  }
+
   return (
-    <div id="modal">
+    <div id="modal" onClick={detectOutsideOfModal}>
       <div id="content">
-        <img src="./public/closeWindow.png" onClick={closer}alt="close" />
+        <img src="./public/closeWindow.png" onClick={closer} alt="close" />
         {content({})}
       </div>
     </div>

--- a/app/frontend/src/scss/Modal.scss
+++ b/app/frontend/src/scss/Modal.scss
@@ -1,11 +1,11 @@
-.modal {
+#modal {
   position: fixed;
   top: 0;
   left: 0;
   width:100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.6);
-  .content {
+  #content {
     position: fixed;
     margin: 0;
     padding: 0;
@@ -21,12 +21,4 @@
       height: 30px !important;
     }
   }
-}
-
-.display-block {
-  display: 'block';
-}
-
-.display-none {
-  display: none;
 }

--- a/app/frontend/src/scss/Modal.scss
+++ b/app/frontend/src/scss/Modal.scss
@@ -9,6 +9,7 @@
     position: fixed;
     margin: 0;
     padding: 0;
+    overflow: auto;
     background-color: white;
     top: 50%;
     left: 50%;


### PR DESCRIPTION
### 모달 구현 방식 개선
기존의 모달은 main page 로드 시에 같이 로드되고, 버튼이 눌릴 때 마다 css의 display property를 조작하는 방식으로 구현됐으나,
이런 방식으로는 모달을 사용자가 닫았을 때 componentWillUnmount 함수가 실행되지 않는(컴포넌트가 Unmount 되는것이 아닌 보이지만 않는 것이기 때문) 문제가 있었음. 이러한 구조는 차후에도 충분히 문제가 될 것 같아서 수정함.
### 바깥쪽(반투명 검은 부분)을 누르면 모달이 꺼지도록 개선
닫는 버튼이 작아 닫기 좀 귀찮지만, 그렇다고 닫는 버튼을 키우기에는 보기가 안좋아서 모달의 바깥을 누르면 꺼지도록 개선함