### PR TITLE
FEAT: 모달창 뒤로가기 구현(+모달창 닫힐 때 애니메이션 구현) #32

### DIFF
--- a/app/frontend/src/component/mainpage/MainPage.tsx
+++ b/app/frontend/src/component/mainpage/MainPage.tsx
@@ -55,10 +55,10 @@ const MainPage = (): JSX.Element => {
             <span>게임을 하려면 누르세요!</span>
           </div>
         </div>
-        <ModalController content={() => <h1>Record</h1>} display={isRecordOpen} closer={() => setIsRecordOpen(false)}/>
-        <ModalController content={ChatContent} display={isChatOpen} closer={() => setIsChatOpen(false)}/>
-        <ModalController content={() => <h1>Game</h1>} display={isGameOpen} closer={() => setIsGameOpen(false)}/>
-        <ModalController content={ConfigContent} display={isConfigOpen} closer={() => setIsConfigOpen(false)}/>
+        <ModalController content={() => <h1>Record</h1>} display={isRecordOpen} stateSetter={setIsRecordOpen}/>
+        <ModalController content={ChatContent} display={isChatOpen} stateSetter={setIsChatOpen}/>
+        <ModalController content={() => <h1>Game</h1>} display={isGameOpen} stateSetter={setIsGameOpen}/>
+        <ModalController content={ConfigContent} display={isConfigOpen} stateSetter={setIsConfigOpen}/>
       </main>
     </>
   );

--- a/app/frontend/src/component/modal/Modal.tsx
+++ b/app/frontend/src/component/modal/Modal.tsx
@@ -5,26 +5,26 @@ import ChatContent from './content/ChatContent';
 import ConfigContent from './content/ConfigContent'
 
 /*!
- * @author yochoi
+ * @author yochoi, donglee
  * @brief display 에 맞춰 Modal 컴포넌트를 마운트, 언마운트 해주는 FC
  * @param[in] content: Modal 안에 들어갈 FC
  * @param[in] display: Modal 의 display 여부
- * @param[in] closer: Modal 의 상위 컴포넌트에서 display를 제어해줄 함수
+ * @param[in] stateSetter: Modal의 상위 컴포넌트 state를 조정함으로써 display를 결정함
  */
 
 interface modalControllerProps {
   content: FC;
   display: boolean;
-  closer: () => void;
+  stateSetter: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const ModalController: FC<modalControllerProps> = ({
   content,
   display,
-  closer,
+  stateSetter,
 }): JSX.Element => {
   if (display) {
-    return <Modal content={content} closer={closer} />;
+    return <Modal content={content} stateSetter={stateSetter} />;
   } else {
     return <></>;
   }
@@ -34,15 +34,26 @@ const ModalController: FC<modalControllerProps> = ({
  * @author yochoi
  * @brief FC를 Modal 형태로 띄워주는 컴포넌트
  * @param[in] content: Modal 안에 들어갈 함수형 컴포넌트
- * @param[in] closer: Modal 의 상위 컴포넌트에서 display를 제어해줄 함수
+ * @param[in] stateSetter: Modal의 상위 컴포넌트 state를 조정함으로써 display를 결정함
  */
 
 interface modalPros {
   content: FC;
-  closer: () => void;
+  stateSetter: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Modal: FC<modalPros> = ({ content, closer }): JSX.Element => {
+const Modal: FC<modalPros> = ({ content, stateSetter }): JSX.Element => {
+  
+  /*!
+  * @author donglee
+  * @brief 모달 컴포넌트를 종료할 때 실행하는 함수.
+  *       애니메이션 효과가 끝나는 시간 동안 기다렸다가 stateSetter(false)를 통해 컴포넌트 언마운트시킴
+  */
+  const closer = () => {
+    setTimeout(() => { stateSetter(false); }, 700);
+    hideAnimatedModal();
+  }
+  
   const detectOutsideOfModal = (e: React.MouseEvent) => {
     e.preventDefault();
     if (e.target === e.currentTarget) {
@@ -62,7 +73,7 @@ const Modal: FC<modalPros> = ({ content, closer }): JSX.Element => {
 
   /*!
   * @author donglee
-  * @brief 모달 컴포넌트 style만 바꿔주는 animation 함수
+  * @brief 모달 컴포넌트 나타날 때 style만 바꿔주는 animation 함수
   */
   const showAnimatedModal = () => {
     const modal = document.getElementById("modal");
@@ -75,6 +86,21 @@ const Modal: FC<modalPros> = ({ content, closer }): JSX.Element => {
       "opacity 250ms 500ms ease, transform 350ms 500ms ease";
     content.style.transform = "scale(1)";
   };
+
+  /*!
+  * @author donglee
+  * @brief 모달 컴포넌트 사라질 때 style만 바꿔주는 animation 함수
+  */
+    const hideAnimatedModal = () => {
+      const modal = document.getElementById("modal");
+      const content = document.getElementById("content");
+  
+      modal.style.opacity = "0";
+      modal.style.transition = "opacity 250ms 500ms ease";
+      content.style.opacity = "0";
+      content.style.transform = "scale(0.6)";
+      content.style.transition = "opacity 250ms 250ms ease, transform 300ms 250ms ease";
+    };
 
   useEffect(() => {
     showAnimatedModal();

--- a/app/frontend/src/component/modal/Modal.tsx
+++ b/app/frontend/src/component/modal/Modal.tsx
@@ -1,8 +1,7 @@
 import React, { FC, useEffect } from "react";
 import "/src/scss/Modal.scss";
-
 import ChatContent from './content/ChatContent';
-import ConfigContent from './content/ConfigContent'
+import ConfigContent from './content/ConfigContent';
 
 /*!
  * @author yochoi, donglee
@@ -43,6 +42,7 @@ interface modalPros {
 }
 
 const Modal: FC<modalPros> = ({ content, stateSetter }): JSX.Element => {
+  let isGoBackClicked = false;  //뒤로가기 버튼을 눌렀는지 여부를 저장
   
   /*!
   * @author donglee
@@ -91,21 +91,46 @@ const Modal: FC<modalPros> = ({ content, stateSetter }): JSX.Element => {
   * @author donglee
   * @brief 모달 컴포넌트 사라질 때 style만 바꿔주는 animation 함수
   */
-    const hideAnimatedModal = () => {
-      const modal = document.getElementById("modal");
-      const content = document.getElementById("content");
-  
-      modal.style.opacity = "0";
-      modal.style.transition = "opacity 250ms 500ms ease";
-      content.style.opacity = "0";
-      content.style.transform = "scale(0.6)";
-      content.style.transition = "opacity 250ms 250ms ease, transform 300ms 250ms ease";
-    };
+  const hideAnimatedModal = () => {
+    const modal = document.getElementById("modal");
+    const content = document.getElementById("content");
 
+    modal.style.opacity = "0";
+    modal.style.transition = "opacity 250ms 500ms ease";
+    content.style.opacity = "0";
+    content.style.transform = "scale(0.6)";
+    content.style.transition = "opacity 250ms 250ms ease, transform 300ms 250ms ease";
+  };
+
+  /*!
+  * @author donglee
+  * @brief 모달 컴포넌트에서 브라우저 뒤로가기 버튼을 눌렀을 때
+  *        이전 history로 이동하는 것을 방지하고 단순히 모달 컴포넌트만 닫힘
+  */
+  const goBack = () => {
+    isGoBackClicked = true;
+    closer();
+  };
+
+  /*!
+  * @author donglee
+  * @brief -history에 새로운 state를 넣어서 뒤로가기시에 모달창만 꺼지도록함
+  *        -SEC키와 뒤로가기 버튼에 대한 이벤트리스너를 등록하고 언마운트시에 제거함
+  */
   useEffect(() => {
+    history.pushState({page:"modal"}, document.title);
     showAnimatedModal();
+
     document.addEventListener("keyup", detectESC);
-    return () => document.removeEventListener("keyup", detectESC);
+    window.addEventListener("popstate", goBack);
+    return () => {
+      document.removeEventListener("keyup", detectESC);
+      window.removeEventListener("popstate", goBack);
+      //뒤로가기를 누르지 않고 종료할 경우엔 state가 새로 있으니 뒤로가기를 해줘야함.
+      if (!isGoBackClicked) {
+        history.back();
+      }
+    };
   }, []);
 
   return (


### PR DESCRIPTION
1. 모달창이 닫힐 때 setTimeout을 줘서 애니메이션 효과가 적용되도록 구현했습니다.
이를 위해서 stateSetter 라는 상위 컴포넌트의 setter를 모달컴포넌트의 props로 전달하는 식으로 구성을 약간 바꿨습니다.

2. 모달창에서 뒤로가기를 눌렀을 때 로그인 화면으로 가는 현상을 고쳐서 모달창만 닫히도록 구현했습니다.
이를 위해서 history state에 새로운 state를 만들어줘서 모달창 종료시에 무조건 뒤로가기를 작동시켜서
이전의 mainpage로 가도록 했습니다. 
