### PR TITLE
UPDATE: Modal 컴포넌트 size Props를 넣으면 적용되도록 구현함

### DIFF
--- a/app/frontend/src/component/mainpage/MainPage.tsx
+++ b/app/frontend/src/component/mainpage/MainPage.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from "react";
-import { ModalController, ChatContent, ConfigContent } from '../modal/Modal'
-import NavBar from './navbar/NavBar'
-import '/src/scss/MainPage.scss'
+import { ModalController, ChatContent, ConfigContent } from '../modal/Modal';
+import NavBar from './navbar/NavBar';
+import '/src/scss/MainPage.scss';
 import EasyFetch from './../../utils/EasyFetch';
-import { testFriendList } from '../../dummydata/testFriendList'
+import { testFriendList } from '../../dummydata/testFriendList';
 
 /*!
  * @author yochoi, donglee

--- a/app/frontend/src/component/modal/Modal.tsx
+++ b/app/frontend/src/component/modal/Modal.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect } from "react";
 import "/src/scss/Modal.scss";
 import ChatContent from './content/ChatContent';
 import ConfigContent from './content/ConfigContent';
+import {SMALL_MODAL} from "../../utils/constant";
 
 /*!
  * @author yochoi, donglee
@@ -9,21 +10,24 @@ import ConfigContent from './content/ConfigContent';
  * @param[in] content: Modal 안에 들어갈 FC
  * @param[in] display: Modal 의 display 여부
  * @param[in] stateSetter: Modal의 상위 컴포넌트 state를 조정함으로써 display를 결정함
+ * @param[in] size?: 작은 modal을 만들 때의 사이즈. 기본값은 css에 정의돼있는 값.
  */
 
 interface modalControllerProps {
   content: FC;
   display: boolean;
   stateSetter: React.Dispatch<React.SetStateAction<boolean>>;
+  size?: Array<string>;
 }
 
 const ModalController: FC<modalControllerProps> = ({
   content,
   display,
   stateSetter,
+  size,
 }): JSX.Element => {
   if (display) {
-    return <Modal content={content} stateSetter={stateSetter} />;
+    return <Modal content={content} stateSetter={stateSetter} modalSize={size}/>;
   } else {
     return <></>;
   }
@@ -34,14 +38,16 @@ const ModalController: FC<modalControllerProps> = ({
  * @brief FC를 Modal 형태로 띄워주는 컴포넌트
  * @param[in] content: Modal 안에 들어갈 함수형 컴포넌트
  * @param[in] stateSetter: Modal의 상위 컴포넌트 state를 조정함으로써 display를 결정함
+ * @param[in] modalSize?: ModalController에서 받아오는 modal 사이즈.
  */
 
 interface modalPros {
   content: FC;
   stateSetter: React.Dispatch<React.SetStateAction<boolean>>;
+  modalSize?: Array<string>;
 }
 
-const Modal: FC<modalPros> = ({ content, stateSetter }): JSX.Element => {
+const Modal: FC<modalPros> = ({ content, stateSetter, modalSize }): JSX.Element => {
   let isGoBackClicked = false;  //뒤로가기 버튼을 눌렀는지 여부를 저장
   
   /*!
@@ -114,10 +120,24 @@ const Modal: FC<modalPros> = ({ content, stateSetter }): JSX.Element => {
 
   /*!
   * @author donglee
+  * @brief modal의 사이즈값이 있을 때 css값을 바꿔주는 함수
+  */
+  const initModalSize = () => {
+    if (modalSize) {
+      const modal = document.getElementById("content");
+      
+      modal.style.width = SMALL_MODAL[0];
+      modal.style.height = SMALL_MODAL[1];
+    }
+  };
+
+  /*!
+  * @author donglee
   * @brief -history에 새로운 state를 넣어서 뒤로가기시에 모달창만 꺼지도록함
   *        -SEC키와 뒤로가기 버튼에 대한 이벤트리스너를 등록하고 언마운트시에 제거함
   */
   useEffect(() => {
+    initModalSize();
     history.pushState({page:"modal"}, document.title);
     showAnimatedModal();
 

--- a/app/frontend/src/scss/Modal.scss
+++ b/app/frontend/src/scss/Modal.scss
@@ -1,6 +1,5 @@
 #modal {
   position: fixed;
-  display: block;
   display: -ms-flexbox;
   display: flex;
   -ms-flex-wrap: wrap;
@@ -13,7 +12,7 @@
   width: 100%;
   height: 100%;
   z-index: 100;
-  overflow-x: hidden;
+  overflow: hidden;
   background-color: rgba(15, 17, 16, 0.75);
   opacity: 0;
   transition: opacity 250ms 700ms ease;

--- a/app/frontend/src/utils/constant.ts
+++ b/app/frontend/src/utils/constant.ts
@@ -1,0 +1,1 @@
+export const SMALL_MODAL = ["400px", "500px"];


### PR DESCRIPTION
size? Props가 없으면 기본값으로 scss에 적용된 width, height 값을 갖고 size props가 있는 경우에는 SMALL_MODAL 사이즈로 변경됨.

utils 디렉토리 안에 constant.ts 파일 추가해서 SMALL_MODAL 정의해놨습니다. 앞으로 상수들 정의해서 쓰면 좋을 것 같습니다!