### PR TITLE
Add Image onError exception handling

### DIFF
--- a/app/frontend/src/component/mainpage/navbar/NavBar.tsx
+++ b/app/frontend/src/component/mainpage/navbar/NavBar.tsx
@@ -1,4 +1,4 @@
-import { FC, SetStateAction, useEffect, useState } from "react";
+import { FC, useEffect, useState, useRef } from "react";
 import { Link, Route, RouteComponentProps, withRouter } from "react-router-dom";
 import AddFriend from "./addFriend/AddFriend";
 import FriendList from "./friendlist/FriendList";
@@ -39,6 +39,8 @@ const NavBar: FC<navBarProps & RouteComponentProps> = (props): JSX.Element => {
   const [myNick, setMyNick] = useState("");
   const [myAvatar, setMyAvatar] = useState("");
 
+  const avatarImgRef = useRef(null);
+
   /*!
    * @author donglee
    * @brief API /user 에서 프로필 정보를 요청해서 state에 저장함
@@ -64,7 +66,11 @@ const NavBar: FC<navBarProps & RouteComponentProps> = (props): JSX.Element => {
           <Link to={`${props.match.url}/profile/${userInfo.nick}`}>
           <img
             id="avatarImg"
+            ref={avatarImgRef}
             src={userInfo.avatar_url}
+            onError={() => {
+              avatarImgRef.current.src = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+            }}
             alt="Avatar" />
           </Link>
           <h2>{myNick}</h2>

--- a/app/frontend/src/component/modal/content/profile/ProfileContent.tsx
+++ b/app/frontend/src/component/modal/content/profile/ProfileContent.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FormEvent, SetStateAction, useEffect, useState } from "react";
+import React, { Dispatch, FormEvent, SetStateAction, useEffect, useRef, useState } from "react";
 import { withRouter, RouteComponentProps, Link, Route, useParams } from "react-router-dom";
 import "/src/scss/content/profile/ProfileContent.scss";
 import Modal from "../../Modal";
@@ -43,6 +43,8 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
   const [isEditNickClicked, setIsEditNickClicked] = useState(false);
   const [nickToEdit, setNickToEdit] = useState("");
   const [isAlreadyFriend, setIsAlreadyFriend] = useState(false);
+
+  const avatarImgRef = useRef(null);
 
   //url parameter로 넘어오는 nick 문자열 저장
   const { nick } = useParams<{nick: string}>();
@@ -228,7 +230,11 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
             </Link>
           </div>
           <div id="avatar-container">
-            <img className="pr-avatar" src={userInfo.avatar_url} alt="프로필사진" />
+            <img className="pr-avatar"
+              ref={avatarImgRef}
+              src={userInfo.avatar_url}
+              onError={() => {avatarImgRef.current.src = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="}}
+              alt="프로필사진" />
           </div>
           <div id="user-info">
             <div id="user-id">


### PR DESCRIPTION
이미지를 백엔드에서 불러오지 못하는 경우 css 가 깨질 염려가 있어서
이미지를 불러오는 중에 에러가 생기면 useRef 를 사용해서 투명 이미지를 불러오도록 예외처리를 했습니다.

```JSX
avatarImgRef.current.src = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
```
투명 이미지를 하나 다운받기는 뭐해서 base64 라는걸 활용해서 이미지를 대체했습니다.
close #129 