### PR TITLE
Fix firefox font error

### DIFF
--- a/app/frontend/src/App.scss
+++ b/app/frontend/src/App.scss
@@ -33,3 +33,11 @@ html {
     overflow: hidden;
   }
 }
+
+// 브라우저가 mozilla면 다른 폰트 사용
+
+@-moz-document url-prefix() {
+  html {
+    font-family: 'Helvetica Neue', sans-serif;
+  }
+}


### PR DESCRIPTION
```console
downloadable font: rejected by sanitizer
```
위와 같은 에러가 나온건 폰트의 레이아웃에 문제가 있다고 firefox가 판단했기 때문이라고 합니다.
firefox 설정에서 위의 경고를 띄울지 말지 결정할 수 있지만, 과제에서 에러가 없어야 한다고 명시되어 있는 만큼
프론트에서 수정하는게 맞는 것 같습니다.
  
그래서 브라우저가 firefox 면 기본 폰트를 사용토록 조치했습니다. (심사숙고해서 가장 예쁜거 씀)
<img width="916" alt="image" src="https://user-images.githubusercontent.com/50163242/132947297-7f038f3d-0edb-4223-8d98-10eee56fb707.png">
close #109 
