### PR TITLE
비공개방 만들기 후 비밀번호 없이 자동 입장

### DIFF
--- a/app/frontend/src/component/modal/content/chat/MakeChatRoom.tsx
+++ b/app/frontend/src/component/modal/content/chat/MakeChatRoom.tsx
@@ -56,7 +56,7 @@ const MakeChatRoom: FC = (): JSX.Element => {
   };
 
   if (channelId) {
-    return <Redirect to={`/mainpage/chat/${channelId}`}></Redirect>
+    return <Redirect to={{pathname: `/mainpage/chat/${channelId}`, state: {myself: true}}}></Redirect>
   } else {
     return (
       <div className="mc-container">

--- a/app/frontend/src/scss/content/chat/MakeChatRoom.scss
+++ b/app/frontend/src/scss/content/chat/MakeChatRoom.scss
@@ -87,7 +87,7 @@ div.mc-container {
 
   button.mc-make {
     position: absolute;
-    top: 64vh;
+    top: 465px;
     width: 341px;
     height: 35px;
     color: #fff;


### PR DESCRIPTION
- 이전에는 비공개방을 만들면 비밀번호를 입력해야 입장이 가능했는데 여기서 입장하지 않고 뒤로가기를 했을 때 채팅방에 아무도 없는데 정상적으로 생성되는 버그가 있었습니다.

하지만 처음에 비공개방을 만들 때는 비밀번호 입력없이 만든 사람은 자동으로 입장이 되도록 수정했습니다.
하지만 나갔다가 다시 입장하려고 할 때는 비밀번호를 입력해야 입장이 가능하도록 했습니다.(방 소유자가 변경될 수도 있으니)

- 채팅방 만들기 버튼 고정 픽셀로 수정했습니다.

-> MakeChatRoom 에서 Redirect 하는 부분에 객체를 props로 넣음으로써 해당 props가 있으면 state를 변경해서 Password 컴포넌트를 안 보여주게 함으로써 구현했습니다. 하지만 채팅 목록에서 입장할 때는 Redirect props가 없으니 Password 컴포넌트가 보이게 됩니다. 