### PR TITLE
Update UserInfo to global Object using useReducer and contextAPI

### DIFF
--- a/app/backend/ormconfig.ts
+++ b/app/backend/ormconfig.ts
@@ -39,7 +39,7 @@ const config: TypeOrmModuleOptions = {
   cli: { migrationsDir: 'src/migrations' },
   autoLoadEntities: true,
   synchronize: false,
-  logging: true,
+  logging: false,
   keepConnectionAlive: true,
 };
 

--- a/app/frontend/src/component/mainpage/MainPage.tsx
+++ b/app/frontend/src/component/mainpage/MainPage.tsx
@@ -1,24 +1,50 @@
 import Modal, { ChatContent, RecordContent, GameContent } from '../modal/Modal';
 import NavBar from './navbar/NavBar';
 import Dm from './dm/Dm';
-import { useEffect, useState } from "react";
+import { createContext, useEffect, useState } from "react";
 import "/src/scss/mainpage/MainPage.scss";
 import "/src/scss/mainpage/MainPage-media.scss";
 import "/src/scss/mainpage/MainPage-mobile.scss";
 import { Link, Route, Switch } from "react-router-dom";
+import EasyFetch from '../../utils/EasyFetch';
+import Loading from '../loading/Loading';
 
 /*!
  * @author yochoi, donglee
  * @brief NavBar를 상시 보이게 하고 Record, Match-game, Chat 모달 버튼이 있는 메인페이지
  */
 
+interface UserInfo {
+  user_id: string;
+  nick: string;
+  avatar_url: string;
+  total_games: number;
+  win_games: number;
+  loss_games: number;
+  ladder_level: number;
+  status: string;
+}
+
+export const UserInfoContext = createContext(null);
+
 const MainPage = ({match}): JSX.Element => {
 
   const [isDmOpen, setIsDmOpen] = useState(false);
   const [updateFriendList, setUpdateFriendList] = useState({state: "", user_id: ""});
   const [unReadMsg, setUnReadMsg] = useState(1);
+  const [userInfo, setUserInfo] = useState<UserInfo>(null);
+
+  const getUserInfo = async () => {
+    const easyfetch = new EasyFetch(`${global.BE_HOST}/users/myself`);
+    const res = await easyfetch.fetch();
+
+    if (res.err_msg) return null;
+    setUserInfo(res);
+    return res;
+  }
 
   useEffect(() => {
+    getUserInfo();
     global.socket.on("online", ({user_id}) => {
       setUpdateFriendList({state: "online", user_id: user_id});
     });
@@ -30,52 +56,58 @@ const MainPage = ({match}): JSX.Element => {
     });
   }, []);
 
-  return (
-    <>
-      <NavBar update={updateFriendList}/>
-      <main>
-        <div id="button-container">
-          <Link
-            to={`${match.url}/record`}
-            style={{textDecoration: "none"}}
-            className="buttons"
-            id="record">
-            전적
-            <span className="mp-explain-span">게임 전적을 보려면 누르세요!</span>
-          </Link>
-          <Link
-            to={`${match.url}/chat`}
-            style={{textDecoration: "none"}}
-            className="buttons"
-            id="chat">
-            채팅
-            <span className="mp-explain-span">친구와 채팅을 하려면 누르세요!</span>
-          </Link>
-          <Link
-            to={`${match.path}/game`}
-            style={{textDecoration: "none"}}
-            className="buttons"
-            id="game">
-              게임
-            <span className="mp-explain-span">게임을 하려면 누르세요!</span>
-          </Link>
-          <section id="dm-section">
-            <Dm isDmOpen={isDmOpen}/>
-            <button id="dm-controll-button" onClick={() => setIsDmOpen(!isDmOpen)}>
-              {unReadMsg && <div className="un-read-msg">{unReadMsg}</div>}
-              {!isDmOpen && <img className="dm-img dm" src="/public/chat-reverse.svg" />}
-              {isDmOpen && <img className="dm-img closer" src="/public/DM-closer.svg" />}
-            </button>
-          </section>
-        </div>
-        <Switch>
-          <Route path={`${match.path}/record`}><Modal id={Date.now()} content={<RecordContent/>} /></Route>
-          <Route path={`${match.path}/chat`}><Modal id={Date.now()} content={<ChatContent/>} /></Route>
-          <Route path={`${match.path}/game`}><Modal id={Date.now()} content={<GameContent/>} /></Route>
-        </Switch>
-      </main>
-    </>
-  );
+  if (userInfo) {
+    return (
+      <>
+        {console.log("MyInfo: ", userInfo)}
+        <UserInfoContext.Provider value={userInfo}>
+        <NavBar update={updateFriendList}/>
+        <main>
+          <div id="button-container">
+            <Link
+              to={`${match.url}/record`}
+              style={{textDecoration: "none"}}
+              className="buttons"
+              id="record">
+              전적
+              <span className="mp-explain-span">게임 전적을 보려면 누르세요!</span>
+            </Link>
+            <Link
+              to={`${match.url}/chat`}
+              style={{textDecoration: "none"}}
+              className="buttons"
+              id="chat">
+              채팅
+              <span className="mp-explain-span">친구와 채팅을 하려면 누르세요!</span>
+            </Link>
+            <Link
+              to={`${match.path}/game`}
+              style={{textDecoration: "none"}}
+              className="buttons"
+              id="game">
+                게임
+              <span className="mp-explain-span">게임을 하려면 누르세요!</span>
+            </Link>
+            <section id="dm-section">
+              <Dm isDmOpen={isDmOpen}/>
+              <button id="dm-controll-button" onClick={() => setIsDmOpen(!isDmOpen)}>
+                {unReadMsg && <div className="un-read-msg">{unReadMsg}</div>}
+                {!isDmOpen && <img className="dm-img dm" src="/public/chat-reverse.svg" />}
+                {isDmOpen && <img className="dm-img closer" src="/public/DM-closer.svg" />}
+              </button>
+            </section>
+          </div>
+          <Switch>
+            <Route path={`${match.path}/record`}><Modal id={Date.now()} content={<RecordContent/>} /></Route>
+            <Route path={`${match.path}/chat`}><Modal id={Date.now()} content={<ChatContent/>} /></Route>
+            <Route path={`${match.path}/game`}><Modal id={Date.now()} content={<GameContent/>} /></Route>
+          </Switch>
+        </main>
+        </UserInfoContext.Provider>
+      </>
+    );
+  }
+  return <></>;
 }
 
 export default MainPage;

--- a/app/frontend/src/component/mainpage/MainPage.tsx
+++ b/app/frontend/src/component/mainpage/MainPage.tsx
@@ -25,6 +25,10 @@ interface UserInfo {
   status: string;
 }
 
+/*!
+ * @author donglee
+ * @brief 최초 로그인시에 API에서 받아온 사용자 정보로 userInfoState를 초기화함
+ */
 const userInfoinit = (userInfo: UserInfo) => {
   if (userInfo) {
     return {
@@ -40,6 +44,10 @@ const userInfoinit = (userInfo: UserInfo) => {
   }
 }
 
+/*!
+ * @author donglee
+ * @brief 전역으로 사용될 userInfo객체를 초기화, 업데이트 하는 reducer함수
+ */
 const userInfoReducer = (state, action) => {
   switch (action.type) {
     case "CHANGE":
@@ -67,6 +75,11 @@ const MainPage = ({match}): JSX.Element => {
     return res;
   }
 
+  /*!
+   * @author donglee, yochoi
+   * @brief - 로그인한 사용자 정보를 가져온 후 전역으로 사용될 userInfoState를 업데이트함
+   *        - 전역으로 사용될 소켓 연결
+   */
   useEffect(() => {
     getUserInfo()
     .then((res) => userInfoDispatch({type: "INIT", info: res}));

--- a/app/frontend/src/component/mainpage/navbar/NavBar.tsx
+++ b/app/frontend/src/component/mainpage/navbar/NavBar.tsx
@@ -30,28 +30,17 @@ interface UserInfo {
 }
 
 const NavBar: FC<{update: {state: string, user_id: string}} & RouteComponentProps> = (props): JSX.Element => {
+  
+  const userInfo = useContext(UserInfoContext);
 
   const [isFriendListOpen, setIsFriendListOpen] = useState(false);
   const [isAddFriendOpen, setIsAddFriendOpen] = useState(false);
-  // const [userInfo, setUserInfo] = useState<UserInfo>();
-  const [myNick, setMyNick] = useState("");
+  const [myNick, setMyNick] = useState(userInfo.nick);
   const [myAvatar, setMyAvatar] = useState("");
   const [friendList, setFriendList] = useState<UserInfo[]>(null);
 
   const avatarImgRef = useRef(null);
-  let userInfo = useContext(UserInfoContext);
 
-  /*!
-   * @author donglee
-   * @brief API /user 에서 프로필 정보를 요청해서 state에 저장함
-   */
-  // const getUserInfo = async () => {
-  //   const easyfetch = new EasyFetch(`${global.BE_HOST}/users/myself`);
-  //   const res = await easyfetch.fetch();
-
-  //   setUserInfo(res);
-  //   return res;
-  // };
 
   /*!
    * @author donglee
@@ -64,85 +53,61 @@ const NavBar: FC<{update: {state: string, user_id: string}} & RouteComponentProp
     setFriendList(res.friendList);
   };
 
-  /*!
-   * @author donglee
-   * @brief Profile에서 닉네임 변경 시 NavBar에서도 userInfo를 업데이트 함
-   */
-  // useEffect(() => {
-  //   if (userInfo) {
-  //     const updatedUserInfo = {...userInfo};
-
-  //     updatedUserInfo.nick = myNick;
-  //     setUserInfo(updatedUserInfo);
-  //   }
-  // }, [myNick])
-
-  useEffect(() => {
-    // getUserInfo()
-    //   .then((res) => setMyNick(res.nick));
-    getFriendList();
-  },[]);
-
   useEffect(() => {
     getFriendList();
   }, [props.update]);
 
-  if (userInfo) {
-    return (
-      <nav className="menu">
-        <header className="avatar">
-          <Link to={`${props.match.url}/profile/${userInfo.nick}`}>
-          <img
-            id="avatarImg"
-            ref={avatarImgRef}
-            src={userInfo.avatar_url}
-            onError={() => {
-              avatarImgRef.current.src = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+  return (
+    <nav className="menu">
+      <header className="avatar">
+        <Link to={`${props.match.url}/profile/${userInfo.nick}`}>
+        <img
+          id="avatarImg"
+          ref={avatarImgRef}
+          src={userInfo.avatar_url}
+          onError={() => {
+            avatarImgRef.current.src = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+          }}
+          alt="Avatar" />
+        </Link>
+        <h2>{userInfo.nick}</h2>
+      </header>
+      <ul className="nav-ul">
+        <li className="nav-list-button" id="nav-friend" onClick={() => setIsFriendListOpen(!isFriendListOpen)}>
+          <img className="nav-list-img" src="/public/users.svg"/>
+          <span className="nav-list-span">친구</span>
+          <img 
+            id="icon-plus"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsAddFriendOpen(!isAddFriendOpen);
             }}
-            alt="Avatar" />
-          </Link>
-          {/* <h2>{myNick}</h2> */}
-          <h2>{userInfo.nick}</h2>
-        </header>
-        <ul className="nav-ul">
-          <li className="nav-list-button" id="nav-friend" onClick={() => setIsFriendListOpen(!isFriendListOpen)}>
-            <img className="nav-list-img" src="/public/users.svg"/>
-            <span className="nav-list-span">친구</span>
-            <img 
-              id="icon-plus"
-              onClick={(e) => {
-                e.stopPropagation();
-                setIsAddFriendOpen(!isAddFriendOpen);
-              }}
-              src="/public/plus.svg"/>
-            {isAddFriendOpen ? <AddFriend setState={setIsAddFriendOpen} friendList={friendList} setFriendList={setFriendList} /> : <></>}
+            src="/public/plus.svg"/>
+          {isAddFriendOpen ? <AddFriend setState={setIsAddFriendOpen} friendList={friendList} setFriendList={setFriendList} /> : <></>}
+        </li>
+        {isFriendListOpen ? <FriendList friendList={friendList} setFriendList={setFriendList} /> : <></>}
+        <Link to={`${props.match.url}/record`} style={{color: "inherit", textDecoration: "none"}}>
+          <li className="nav-list-button">
+            <img className="nav-list-img" src="/public/line-graph.svg"/>
+            <span className="nav-list-span">전적</span>
           </li>
-          {isFriendListOpen ? <FriendList friendList={friendList} setFriendList={setFriendList} /> : <></>}
-          <Link to={`${props.match.url}/record`} style={{color: "inherit", textDecoration: "none"}}>
-            <li className="nav-list-button">
-              <img className="nav-list-img" src="/public/line-graph.svg"/>
-              <span className="nav-list-span">전적</span>
-            </li>
-          </Link>
-          <Link to={`${props.match.url}/chat`} style={{color: "inherit", textDecoration: "none"}}>
-            <li className="nav-list-button">
-              <img className="nav-list-img" src="/public/chat.svg"/>
-              <span className="nav-list-span">채팅</span>
-            </li>
-          </Link>
-          <Link to={`${props.match.url}/game`} style={{color: "inherit", textDecoration: "none"}}>
-            <li className="nav-list-button">
-              <img className="nav-list-img" src="/public/controller-play.svg"/>
-              <span className="nav-list-span">게임하기</span>
-            </li>
-          </Link>
-        </ul>
-        <Route path={`${props.match.path}/profile/:nick`}><Modal id={Date.now()} content={<ProfileContent myNickSetter={setMyNick} myAvatarSetter={setMyAvatar}/>} smallModal/></Route>
-      </nav>
-    );
-  } else {
-    return ( <Loading color="#fff" style={{width: "70px", height: "70px", marginLeft: "30px"}}/> );
-  }
+        </Link>
+        <Link to={`${props.match.url}/chat`} style={{color: "inherit", textDecoration: "none"}}>
+          <li className="nav-list-button">
+            <img className="nav-list-img" src="/public/chat.svg"/>
+            <span className="nav-list-span">채팅</span>
+          </li>
+        </Link>
+        <Link to={`${props.match.url}/game`} style={{color: "inherit", textDecoration: "none"}}>
+          <li className="nav-list-button">
+            <img className="nav-list-img" src="/public/controller-play.svg"/>
+            <span className="nav-list-span">게임하기</span>
+          </li>
+        </Link>
+      </ul>
+      <Route path={`${props.match.path}/profile/:nick`}><Modal id={Date.now()} content={<ProfileContent />} smallModal/></Route>
+    </nav>
+  );
 };
 
 export default withRouter(NavBar);

--- a/app/frontend/src/component/mainpage/navbar/NavBar.tsx
+++ b/app/frontend/src/component/mainpage/navbar/NavBar.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useState, useRef, useContext } from "react";
 import { Link, Route, RouteComponentProps, withRouter } from "react-router-dom";
-import { io } from "socket.io-client";
 import AddFriend from "./addFriend/AddFriend";
 import FriendList from "./friendlist/FriendList";
 import "/src/scss/navbar/NavBar.scss";
@@ -9,7 +8,6 @@ import "/src/scss/navbar/NavBar-mobile.scss";
 import Modal from "../../modal/Modal";
 import EasyFetch from "../../../utils/EasyFetch";
 import ProfileContent from "../../modal/content/profile/ProfileContent";
-import Loading from "../../loading/Loading";
 import { UserInfoContext } from "../MainPage";
 
 /*!
@@ -35,8 +33,6 @@ const NavBar: FC<{update: {state: string, user_id: string}} & RouteComponentProp
 
   const [isFriendListOpen, setIsFriendListOpen] = useState(false);
   const [isAddFriendOpen, setIsAddFriendOpen] = useState(false);
-  const [myNick, setMyNick] = useState(userInfo.nick);
-  const [myAvatar, setMyAvatar] = useState("");
   const [friendList, setFriendList] = useState<UserInfo[]>(null);
 
   const avatarImgRef = useRef(null);

--- a/app/frontend/src/component/mainpage/navbar/NavBar.tsx
+++ b/app/frontend/src/component/mainpage/navbar/NavBar.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState, useRef } from "react";
+import { FC, useEffect, useState, useRef, useContext } from "react";
 import { Link, Route, RouteComponentProps, withRouter } from "react-router-dom";
 import { io } from "socket.io-client";
 import AddFriend from "./addFriend/AddFriend";
@@ -10,6 +10,7 @@ import Modal from "../../modal/Modal";
 import EasyFetch from "../../../utils/EasyFetch";
 import ProfileContent from "../../modal/content/profile/ProfileContent";
 import Loading from "../../loading/Loading";
+import { UserInfoContext } from "../MainPage";
 
 /*!
  * @author donglee
@@ -32,24 +33,25 @@ const NavBar: FC<{update: {state: string, user_id: string}} & RouteComponentProp
 
   const [isFriendListOpen, setIsFriendListOpen] = useState(false);
   const [isAddFriendOpen, setIsAddFriendOpen] = useState(false);
-  const [userInfo, setUserInfo] = useState<UserInfo>();
+  // const [userInfo, setUserInfo] = useState<UserInfo>();
   const [myNick, setMyNick] = useState("");
   const [myAvatar, setMyAvatar] = useState("");
   const [friendList, setFriendList] = useState<UserInfo[]>(null);
 
   const avatarImgRef = useRef(null);
+  let userInfo = useContext(UserInfoContext);
 
   /*!
    * @author donglee
    * @brief API /user 에서 프로필 정보를 요청해서 state에 저장함
    */
-  const getUserInfo = async () => {
-    const easyfetch = new EasyFetch(`${global.BE_HOST}/users/myself`);
-    const res = await easyfetch.fetch();
+  // const getUserInfo = async () => {
+  //   const easyfetch = new EasyFetch(`${global.BE_HOST}/users/myself`);
+  //   const res = await easyfetch.fetch();
 
-    setUserInfo(res);
-    return res;
-  };
+  //   setUserInfo(res);
+  //   return res;
+  // };
 
   /*!
    * @author donglee
@@ -66,18 +68,18 @@ const NavBar: FC<{update: {state: string, user_id: string}} & RouteComponentProp
    * @author donglee
    * @brief Profile에서 닉네임 변경 시 NavBar에서도 userInfo를 업데이트 함
    */
-  useEffect(() => {
-    if (userInfo) {
-      const updatedUserInfo = {...userInfo};
+  // useEffect(() => {
+  //   if (userInfo) {
+  //     const updatedUserInfo = {...userInfo};
 
-      updatedUserInfo.nick = myNick;
-      setUserInfo(updatedUserInfo);
-    }
-  }, [myNick])
+  //     updatedUserInfo.nick = myNick;
+  //     setUserInfo(updatedUserInfo);
+  //   }
+  // }, [myNick])
 
   useEffect(() => {
-    getUserInfo()
-      .then((res) => setMyNick(res.nick));
+    // getUserInfo()
+    //   .then((res) => setMyNick(res.nick));
     getFriendList();
   },[]);
 
@@ -99,7 +101,8 @@ const NavBar: FC<{update: {state: string, user_id: string}} & RouteComponentProp
             }}
             alt="Avatar" />
           </Link>
-          <h2>{myNick}</h2>
+          {/* <h2>{myNick}</h2> */}
+          <h2>{userInfo.nick}</h2>
         </header>
         <ul className="nav-ul">
           <li className="nav-list-button" id="nav-friend" onClick={() => setIsFriendListOpen(!isFriendListOpen)}>

--- a/app/frontend/src/component/modal/content/profile/ProfileContent.tsx
+++ b/app/frontend/src/component/modal/content/profile/ProfileContent.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FormEvent, SetStateAction, useEffect, useRef, useState } from "react";
+import React, { Dispatch, FormEvent, SetStateAction, useContext, useEffect, useRef, useState } from "react";
 import { withRouter, RouteComponentProps, Link, Route, useParams } from "react-router-dom";
 import "/src/scss/content/profile/ProfileContent.scss";
 import Modal from "../../Modal";
@@ -7,6 +7,9 @@ import RecordContent from "../record/RecordContent";
 import EasyFetch from "../../../../utils/EasyFetch";
 import { setAchievementImg, setAchievementStr } from "../../../../utils/setAchievement";
 import Loading from "../../../loading/Loading";
+import { UserInfoContext } from "../../../mainpage/MainPage";
+
+/* MainPage에서 계속 정보를 받아오는 것은 아니였다. 그래서 닉 바꾸는 거에 대해서 어떻게 해야 할 지 고민해야 된다. */
 
 /*!
  * @author donglee
@@ -39,6 +42,8 @@ interface ProfileContentProps {
 }
 
 const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (props) => {
+
+  const myInfo = useContext(UserInfoContext);
 
   const [userInfo, setUserInfo] = useState<UserInfo>();
   const [isEditNickClicked, setIsEditNickClicked] = useState(false);
@@ -98,7 +103,7 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
       "nick": nickToEdit,
       "avatar_url": userInfo.avatar_url
     }
-    const res = await (await easyfetch.fetch(body)).json();
+    const res = await easyfetch.fetch(body);
     
     if (res.err_msg !== "에러가 없습니다.") {
       alert(`"${nickToEdit}" 은(는) 이미 존재하는 닉네임입니다.`);
@@ -165,7 +170,7 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
 		const body = {
 			"friend_nick": nick
 		};
-		const res = await (await easyfetch.fetch(body)).json();
+		const res = await easyfetch.fetch(body);
 
 		if (res.err_msg !== "에러가 없습니다.") {
 			alert(res.err_msg);
@@ -206,7 +211,7 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
 		const body = {
 			"block_nick": nick,
 		};
-		const res = await (await easyfetch.fetch(body)).json();
+		const res = await easyfetch.fetch(body);
 
 		if (res.err_msg !== "에러가 없습니다.") {
 			alert("사용자의 닉네임이 변경됐을 수 있습니다. 프로필을 끄고 다시 시도하십시오.");
@@ -266,10 +271,13 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
    * @detail 프로필을 열 때 가장 먼저 나의 프로필인지 다른 사용자것인지를 판별
    */
   const setMineOrOthers = async () => {
-    const easyfetch = new EasyFetch(`${global.BE_HOST}/users/myself`);
-    const res = await easyfetch.fetch()
+    // const easyfetch = new EasyFetch(`${global.BE_HOST}/users/myself`);
+    // const res = await easyfetch.fetch()
 
-    if (res.nick === nick) {
+    // if (res.nick === nick) {
+    //   setIsMyProfile(true);
+    // }
+    if (nick === myInfo.nick) {
       setIsMyProfile(true);
     }
   };

--- a/app/frontend/src/component/modal/content/profile/ProfileContent.tsx
+++ b/app/frontend/src/component/modal/content/profile/ProfileContent.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FormEvent, MouseEvent, SetStateAction, useContext, useEffect, useRef, useState } from "react";
+import React, { FormEvent, MouseEvent, useContext, useEffect, useRef, useState } from "react";
 import { withRouter, RouteComponentProps, Link, Route, useParams } from "react-router-dom";
 import "/src/scss/content/profile/ProfileContent.scss";
 import Modal from "../../Modal";

--- a/app/frontend/src/component/modal/content/profile/ProfileContent.tsx
+++ b/app/frontend/src/component/modal/content/profile/ProfileContent.tsx
@@ -43,8 +43,6 @@ const ProfileContent: React.FC<RouteComponentProps> = (props) => {
   //url parameter로 넘어오는 nick 문자열 저장
   const { nick } = useParams<{nick: string}>();
 
-  console.log("how many?", isMyProfile, myInfo);
-
   /*!
    * @author donglee
    * @brief 닉네임 변경 버튼을 눌렀을 때 현재 닉네임 텍스트가 자동으로 하이라이트되는 함수
@@ -269,12 +267,13 @@ const ProfileContent: React.FC<RouteComponentProps> = (props) => {
 
   /*!
    * @author donglee
-   * @detail 다른 사용자의 경우 프로필 정보를 API로 받아온다
+   * @detail 내 프로필인지 다른 사용자의 프로필인지 검사한다
+   *         다른 사용자의 경우 프로필 정보를 API로 받아온다
    *         이미 친구인지, 차단한 친구인지 정보를 받아온다
    */
   useEffect(() => {
     setIsMyProfile(nick === myInfo.nick);
-    if (!isMyProfile) {
+    if (nick !== myInfo.nick) {
       getOtherUserInfo();
       getIsAlreadyFriend();
       getIsBlockedFriend();
@@ -282,6 +281,7 @@ const ProfileContent: React.FC<RouteComponentProps> = (props) => {
   }, []);
 
   if (isMyProfile) {
+    console.log("mine render");
     return (
       <div id="pr-profile">
         <div className="upper-part">
@@ -316,7 +316,7 @@ const ProfileContent: React.FC<RouteComponentProps> = (props) => {
                   onChange={(e) => setNickToEdit(e.target.value)}
                   onKeyDown={(e) => cancelEditNickKey(e)} />
               </form>
-              <span className={"mf-nick" + (isEditNickClicked ? " mf-nick-clicked" : "")}>{`${myInfo.nick}`}</span>
+              <span className={"mf-nick" + (isEditNickClicked ? " mf-nick-clicked" : "")}>{myInfo.nick}</span>
               <img
                 id="mf-edit-img"
                 src={isEditNickClicked ? "/public/check.png" : "/public/pencil.png"}
@@ -351,6 +351,7 @@ const ProfileContent: React.FC<RouteComponentProps> = (props) => {
   }
 
   if (otherUserInfo) {
+    console.log("other render");
     return (
       <div id="pr-profile">
         <div className="upper-part user-profile">
@@ -399,7 +400,8 @@ const ProfileContent: React.FC<RouteComponentProps> = (props) => {
       </div>
     );
   }
-
+  
+  console.log("loading render");
   return (
     <Loading color="grey" style={{width: "100px", height: "100px", position: "absolute", left: "38%", top: "40%"}} />
   );

--- a/app/frontend/src/component/modal/content/profile/ProfileContent.tsx
+++ b/app/frontend/src/component/modal/content/profile/ProfileContent.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FormEvent, SetStateAction, useContext, useEffect, useRef, useState } from "react";
+import React, { Dispatch, FormEvent, MouseEvent, SetStateAction, useContext, useEffect, useRef, useState } from "react";
 import { withRouter, RouteComponentProps, Link, Route, useParams } from "react-router-dom";
 import "/src/scss/content/profile/ProfileContent.scss";
 import Modal from "../../Modal";
@@ -7,9 +7,7 @@ import RecordContent from "../record/RecordContent";
 import EasyFetch from "../../../../utils/EasyFetch";
 import { setAchievementImg, setAchievementStr } from "../../../../utils/setAchievement";
 import Loading from "../../../loading/Loading";
-import { UserInfoContext } from "../../../mainpage/MainPage";
-
-/* MainPage에서 계속 정보를 받아오는 것은 아니였다. 그래서 닉 바꾸는 거에 대해서 어떻게 해야 할 지 고민해야 된다. */
+import { UserInfoContext, UserInfoDispatchContext } from "../../../mainpage/MainPage";
 
 /*!
  * @author donglee
@@ -28,24 +26,12 @@ interface UserInfo {
   status: string;
 }
 
-/*!
- * @author donglee
- * @param[in] myNickSetter: 프로필 컴포넌트에서 닉네임 수정 시 NavBar에서
- *                         props로 넘어온 setMyNick stateSetter를 바꿔서
- *                         NavBar에서도 업데이트된 nick이 렌더링되도록 함
- * @param[in] myAvatarSetter: 아바타 state setter
- */
-
-interface ProfileContentProps {
-  myNickSetter?: Dispatch<SetStateAction<string>>;
-  myAvatarSetter?: Dispatch<SetStateAction<string>>;
-}
-
-const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (props) => {
+const ProfileContent: React.FC<RouteComponentProps> = (props) => {
 
   const myInfo = useContext(UserInfoContext);
+  const myInfoDispatch = useContext(UserInfoDispatchContext);
 
-  const [userInfo, setUserInfo] = useState<UserInfo>();
+  const [otherUserInfo, setOtherUserInfo] = useState<UserInfo>();
   const [isEditNickClicked, setIsEditNickClicked] = useState(false);
   const [nickToEdit, setNickToEdit] = useState("");
   const [isAlreadyFriend, setIsAlreadyFriend] = useState(false);
@@ -56,6 +42,8 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
 
   //url parameter로 넘어오는 nick 문자열 저장
   const { nick } = useParams<{nick: string}>();
+
+  console.log("how many?", isMyProfile, myInfo);
 
   /*!
    * @author donglee
@@ -81,13 +69,13 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
 
   /*!
    * @author donglee
-   * @brief POST요청 이후 정상 수정 후에 userInfo를 업데이트함
+   * @brief POST요청 이후 정상 수정 후에 전역으로 쓰이는 myInfo를 업데이트함
    */
-  const updateUserInfo = () => {
-    const newUserInfo = {...userInfo};
+  const updateUserInfoState = () => {
+    const newUserInfo = {...myInfo};
 
     newUserInfo.nick = nickToEdit;
-    setUserInfo(newUserInfo);
+    myInfoDispatch({type: "CHANGE", info: newUserInfo});
   };
 
   /*!
@@ -99,42 +87,41 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
     e.preventDefault();
     const easyfetch = new EasyFetch(`${global.BE_HOST}/users/info`, "POST");
     const body = {
-      "user_id": userInfo.user_id,
+      "user_id": myInfo.user_id,
       "nick": nickToEdit,
-      "avatar_url": userInfo.avatar_url
+      "avatar_url": myInfo.avatar_url
     }
     const res = await easyfetch.fetch(body);
     
     if (res.err_msg !== "에러가 없습니다.") {
       alert(`"${nickToEdit}" 은(는) 이미 존재하는 닉네임입니다.`);
-      setNickToEdit(userInfo.nick);
+      setNickToEdit(myInfo.nick);
       return ;
     }
-    updateUserInfo();
-    props.myNickSetter(nickToEdit);
+    updateUserInfoState();
     setIsEditNickClicked(false);
   };
 
   /*!
    * @author donglee
-   * @brief API /users 에서 프로필 정보를 요청해서 state에 저장함
+   * @brief 내가 아닌 다른 사용자 프로필 정보를 요청해서 state에 저장함
    */
-  const getUserInfo = async (): Promise<UserInfo> => {
+  const getOtherUserInfo = async (): Promise<UserInfo> => {
     const easyfetch = new EasyFetch(`${global.BE_HOST}/users?nick=${nick}`);
     const res = await easyfetch.fetch()
 
-    setUserInfo(res);
+    setOtherUserInfo(res);
     return res;
   };
 
   /*!
    * @author donglee
-   * @brief Enter 누르면 저장, ESC 누르면 취소
+   * @brief - Enter 누르면 저장, ESC 누르면 취소
    */
-  const cancelEditNick = (e: React.KeyboardEvent) => {
+  const cancelEditNickKey = (e: React.KeyboardEvent) => {
     if (e.key === "Esc" || e.key === "Escape") {
       setIsEditNickClicked(false);
-      setNickToEdit(userInfo.nick);
+      setNickToEdit(myInfo.nick);
     }
   };
 
@@ -143,11 +130,11 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
    * @detail 닉네임 수정 버튼을 누른 상태에서 input화면과 수정 버튼을 제외한
    *         다른 부분을 눌렀을 때는 수정을 취소하고 원래 닉네임을 보여줌
    */
-  const cancelEdit = (e: MouseEvent, nick: string) => {
+  const cancelEditNickMouse = (e: MouseEvent, nick: string) => {
     if (e.target !== document.getElementById("mf-edit-img") &&
         e.target !== document.getElementsByClassName("mf-edit-nick")[0]) {
       setIsEditNickClicked(false);
-      setNickToEdit(nick);
+      setNickToEdit(myInfo.nick);
     }
   };
 
@@ -266,22 +253,6 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
     }
   };
 
-  /*!
-   * @author donglee
-   * @detail 프로필을 열 때 가장 먼저 나의 프로필인지 다른 사용자것인지를 판별
-   */
-  const setMineOrOthers = async () => {
-    // const easyfetch = new EasyFetch(`${global.BE_HOST}/users/myself`);
-    // const res = await easyfetch.fetch()
-
-    // if (res.nick === nick) {
-    //   setIsMyProfile(true);
-    // }
-    if (nick === myInfo.nick) {
-      setIsMyProfile(true);
-    }
-  };
-
  /*!
   * @author donglee
   * @detail 닉네임 수정을 눌렀을 때만 click이벤트리스너를 등록하고
@@ -291,27 +262,26 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
  
   useEffect(() => {
     if (isEditNickClicked) {
-      window.addEventListener("click", handlerToBeRemoved = function(e) {cancelEdit(e, nickToEdit)});
+      window.addEventListener("click", handlerToBeRemoved = function(e) {cancelEditNickMouse(e, nickToEdit)});
     }
     return (() => window.removeEventListener("click", handlerToBeRemoved));
   }, [isEditNickClicked]);
 
   /*!
    * @author donglee
-   * @detail DB에서 정보를 얻어온 이후에 nickToEdit state를 업데이트한다
+   * @detail 다른 사용자의 경우 프로필 정보를 API로 받아온다
    *         이미 친구인지, 차단한 친구인지 정보를 받아온다
    */
   useEffect(() => {
-    setMineOrOthers()
-      .then(getUserInfo)
-      .then((res) => {setNickToEdit(res.nick); return res;});
+    setIsMyProfile(nick === myInfo.nick);
     if (!isMyProfile) {
+      getOtherUserInfo();
       getIsAlreadyFriend();
       getIsBlockedFriend();
     }
   }, []);
 
-  if (userInfo && isMyProfile) {
+  if (isMyProfile) {
     return (
       <div id="pr-profile">
         <div className="upper-part">
@@ -329,7 +299,7 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
           <div id="avatar-container">
             <img className="pr-avatar"
               ref={avatarImgRef}
-              src={userInfo.avatar_url}
+              src={myInfo.avatar_url}
               onError={() => {avatarImgRef.current.src = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="}}
               alt="프로필사진" />
           </div>
@@ -344,9 +314,9 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
                   maxLength={10}
                   required
                   onChange={(e) => setNickToEdit(e.target.value)}
-                  onKeyDown={(e) => cancelEditNick(e)} />
+                  onKeyDown={(e) => cancelEditNickKey(e)} />
               </form>
-              <span className={"mf-nick" + (isEditNickClicked ? " mf-nick-clicked" : "")}>{`${userInfo.nick}`}</span>
+              <span className={"mf-nick" + (isEditNickClicked ? " mf-nick-clicked" : "")}>{`${myInfo.nick}`}</span>
               <img
                 id="mf-edit-img"
                 src={isEditNickClicked ? "/public/check.png" : "/public/pencil.png"}
@@ -354,14 +324,14 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
                 onClick={!isEditNickClicked ? activateEdit : submitForm}/>
             </div>
             <div id="user-stat">
-              <span id="win">{userInfo.win_games} 승</span>
+              <span id="win">{myInfo.win_games} 승</span>
               <span className="delimiter">|</span>
-              <span id="lose">{userInfo.loss_games} 패</span>
+              <span id="lose">{myInfo.loss_games} 패</span>
               <span className="delimiter">|</span>
-              <span id="score">{userInfo.ladder_level} 점</span>
+              <span id="score">{myInfo.ladder_level} 점</span>
             </div>
-            <div id="user-title">{setAchievementStr(userInfo.ladder_level)}
-              <img id="user-achievement-img" src={setAchievementImg(userInfo.ladder_level)} alt="타이틀로고" />
+            <div id="user-title">{setAchievementStr(myInfo.ladder_level)}
+              <img id="user-achievement-img" src={setAchievementImg(myInfo.ladder_level)} alt="타이틀로고" />
             </div>
           </div>
         </div>
@@ -374,11 +344,13 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
             <span className="pr-explain">클릭하면 회원님의 모든 데이터가 서버에서 삭제됩니다</span>
           </div>
         </div>
-        <Route path={`${props.match.path}/record`}><Modal id={Date.now()} content={<RecordContent nick={nick}/>} /></Route>
-        <Route path={`${props.match.path}/manageFriend`}><Modal id={Date.now()} smallModal content={<ManageFriendContent nick={userInfo.nick}/>} /></Route>
+        <Route path={`${props.match.path}/record`}><Modal id={Date.now()} content={<RecordContent nick={myInfo.nick}/>} /></Route>
+        <Route path={`${props.match.path}/manageFriend`}><Modal id={Date.now()} smallModal content={<ManageFriendContent nick={myInfo.nick}/>} /></Route>
       </div>
     );
-  } else if (userInfo && !isMyProfile) {
+  }
+
+  if (otherUserInfo) {
     return (
       <div id="pr-profile">
         <div className="upper-part user-profile">
@@ -390,24 +362,24 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
             <button className="pr-btn" onClick={requestMatch}>대전 신청</button>
           </div>
           <div id="avatar-container">
-            <img className="pr-avatar" src={userInfo.avatar_url} alt="프로필사진" />
+            <img className="pr-avatar" src={otherUserInfo.avatar_url} alt="프로필사진" />
           </div>
           <div id="user-info">
             <div id="user-id">
               <span className="mf-nick">{`${nick}`}</span>
             </div>
             <div id="user-stat">
-              <span>{userInfo.win_games} 승</span>
+              <span>{otherUserInfo.win_games} 승</span>
               <span className="delimiter">|</span>
-              <span>{userInfo.loss_games} 패</span>
+              <span>{otherUserInfo.loss_games} 패</span>
               <span className="delimiter">|</span>
-              <span>{userInfo.ladder_level} 점</span>
+              <span>{otherUserInfo.ladder_level} 점</span>
               <Link to={`${props.match.url}/record`}>
                 <img className="profile-stat-detail" src="/public/search.svg" alt="상세전적보기" title="상세전적보기"/>
               </Link>
             </div>
-            <div id="user-title">{setAchievementStr(userInfo.ladder_level)}
-              <img id="user-achievement-img" src={setAchievementImg(userInfo.ladder_level)} alt="타이틀로고" />
+            <div id="user-title">{setAchievementStr(otherUserInfo.ladder_level)}
+              <img id="user-achievement-img" src={setAchievementImg(otherUserInfo.ladder_level)} alt="타이틀로고" />
             </div>
           </div>
         </div>
@@ -426,11 +398,11 @@ const ProfileContent: React.FC<ProfileContentProps & RouteComponentProps> = (pro
         <Route path={`${props.match.path}/record`}><Modal id={Date.now()} content={<RecordContent nick={nick}/>} /></Route>
       </div>
     );
-  } else {
-    return (
-      <Loading color="grey" style={{width: "100px", height: "100px", position: "absolute", left: "38%", top: "40%"}} />
-    );
   }
+
+  return (
+    <Loading color="grey" style={{width: "100px", height: "100px", position: "absolute", left: "38%", top: "40%"}} />
+  );
 };
 
 export default withRouter(ProfileContent);


### PR DESCRIPTION
메인페이지에서 userInfo를 API fetch로 받아온 후에 전역으로 사용될 userInfoState를 초기화함

네브바에서 전역객체인 userInfo를 사용해서 정보를 보여줌

프로필에서 닉네임을 수정했을 경우 정상적으로 Navbar에도 업데이트가 잘 적용되도록 함

프로필에서 렌더링이 쓸데없이 여러 번 되는 부분을 다음과 같이 수정함 if (nick !== myInfo.nick) { 다른 사용자 정보 가져오기 }